### PR TITLE
Fix: Address design issues with logo and card layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
 </head>
 <body>
     <h1 class="text-center my-5">Anime series finder</h1>
-    <div class="col-md-2 justify-content-center" style="text-align: center; margin: 0 auto;"><img src="https://scontent-bog1-1.xx.fbcdn.net/v/t1.0-9/71152762_124803278917793_200571102957666304_o.jpg?_nc_cat=103&_nc_sid=09cbfe&_nc_ohc=q0n9ev00a9EAX8rJCCP&_nc_ht=scontent-bog1-1.xx&oh=e883ddecba9a44ff2df4f1f9a2aa1f35&oe=5F63EF57" class="img-fluid" alt="Responsive image"></div>
+    <div class="col-md-2 justify-content-center" style="text-align: center; margin: 0 auto;"><img src="https://picsum.photos/seed/animeseed/150/150" class="img-fluid" alt="Placeholder Logo"></div>
     
 
     <div class="container contenido-principal col-12 col-md-10">

--- a/js/ui.js
+++ b/js/ui.js
@@ -161,7 +161,7 @@ class UI {
             return;
         }
 
-        let htmlContent = '';
+        let cardsHtml = ''; // Accumulates HTML for individual cards
         searchResults.forEach(animeItem => {
             const { // Destructuring from animeItem.attributes
                 canonicalTitle: title,
@@ -175,8 +175,8 @@ class UI {
 
             const imageUrl = posterImage && posterImage.large ? posterImage.large : 'placeholder.jpg'; // Added check for posterImage
 
-            htmlContent += `
-                <div class="col-md-4 mb-4"> <!-- Removed style="display: inline-block;" for Bootstrap's grid system -->
+            cardsHtml += `
+                <div class="col-lg-3 col-md-4 col-sm-6 mb-4">
                     <div class="card h-100">
                         <img class="card-img-top" src="${imageUrl}" alt="${title} Poster" style="max-height: 300px; object-fit: cover;">
                         <div class="card-body d-flex flex-column">
@@ -193,7 +193,8 @@ class UI {
                     </div>
                 </div>`;
         });
-        this.resultsContainer.innerHTML = htmlContent;
+        // After the loop, wrap cardsHtml with a row
+        this.resultsContainer.innerHTML = `<div class="row">${cardsHtml}</div>`;
     }
 
     // Clears previous results


### PR DESCRIPTION
This commit resolves two visual problems:

1.  **Broken Logo:** The previous logo URL (a Facebook content link) had expired. It has been replaced with a placeholder image from picsum.photos (`https://picsum.photos/seed/animeseed/150/150`) in `index.html`. The alt text for the logo has also been updated to "Placeholder Logo".

2.  **Card Layout on Desktop:** Anime search result cards were appearing as one card per row on desktop screens. This has been fixed by:
    *   Modifying `js/ui.js` in the `mostrarEventos` method to use more responsive Bootstrap column classes: `col-lg-3 col-md-4 col-sm-6`. This will display up to 4 cards per row on large screens, 3 on medium, and 2 on small.
    *   Ensuring that the collection of cards generated by `mostrarEventos` is wrapped in a single `<div class="row">`, adhering to Bootstrap's grid structure requirements.

These changes improve the visual presentation and your experience of the application.